### PR TITLE
Switched to official version of PhantomJS archive.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,12 +6,12 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 
 # config
-VERSION="1.9.0"
-S3_BUCKET="stomita-buildpack-phantomjs"
+VERSION="1.9.1"
 
-# s3 packages
-FILE_NAME="buildpack-phantomjs-${VERSION}.tar.gz"
-BUILDPACK_PHANTOMJS_PACKAGE="http://${S3_BUCKET}.s3.amazonaws.com/${FILE_NAME}"
+# Buildpack URL
+ARCHIVE_NAME=phantomjs-${VERSION}-linux-x86_64
+FILE_NAME=${ARCHIVE_NAME}.tar.bz2
+BUILDPACK_PHANTOMJS_PACKAGE=https://phantomjs.googlecode.com/files/${FILE_NAME}
 
 mkdir -p $CACHE_DIR
 if ! [ -e $CACHE_DIR/$FILE_NAME ]; then
@@ -20,5 +20,7 @@ if ! [ -e $CACHE_DIR/$FILE_NAME ]; then
 fi
 
 echo "-----> Extracting PhantomJS ${VERSION} binaries to ${BUILD_DIR}/vendor/phantomjs"
-mkdir -p $BUILD_DIR/vendor/phantomjs
-tar zxf $CACHE_DIR/$FILE_NAME -C $BUILD_DIR/vendor/phantomjs
+mkdir -p $CACHE_DIR/$ARCHIVE_NAME
+mkdir -p $BUILD_DIR/vendor
+tar jxf $CACHE_DIR/$FILE_NAME -C $CACHE_DIR
+mv $CACHE_DIR/$ARCHIVE_NAME $BUILD_DIR/vendor/phantomjs


### PR DESCRIPTION
@stomita, I hope you don't mind this pull request.

I feel that some people like me would feel more security to depend on an phantomJS build from its official download location. It would also nice to use `https` for download to guard against minimal risk of dns spoofing in heroku / amazon aws.

I tested the patch and it was working with heroku.

The downside is that I am not including `fontconfig` and `freetype`.

Since you are the "official third party" buildpack for PhantomJS, even if you don't apply the patch, I wish you consider keeping this PR open for the paranoids out there. :-)

@stomita, thanks a lot for open-source your buildpack. It definitely helped me tremendously!
