### PR TITLE
Update to PhantomJS 2.0.0

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,7 +6,7 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 
 # config
-VERSION="1.9.8"
+VERSION="2.0.0"
 
 # Buildpack URL
 ARCHIVE_NAME=phantomjs-${VERSION}-linux-x86_64


### PR DESCRIPTION
PhantomJS 2.0.0 was released January 23rd. It fixes a few issues for me, so I'd love to see this buildpack updated.